### PR TITLE
updated node names in all tf and tf2 nodes/*.py files to match filena…

### DIFF
--- a/turtle_tf/nodes/dynamic_tf_broadcaster.py
+++ b/turtle_tf/nodes/dynamic_tf_broadcaster.py
@@ -35,20 +35,9 @@ import rospy
 import tf
 import math
 
-if __name__ == '__ STATIC main__':
-    rospy.init_node('my_tf_broadcaster')
-    br = tf.TransformBroadcaster()
-    rate = rospy.Rate(10.0)
-    while not rospy.is_shutdown():
-        br.sendTransform((0.0, 2.0, 0.0),
-                         (0.0, 0.0, 0.0, 1.0),
-                         rospy.Time.now(),
-                         "carrot1",
-                         "turtle1")
-        rate.sleep()
 
 if __name__ == '__main__':
-    rospy.init_node('my_tf_broadcaster')
+    rospy.init_node('dynamic_tf_broadcaster')
     br = tf.TransformBroadcaster()
     rate = rospy.Rate(10.0)
     while not rospy.is_shutdown():

--- a/turtle_tf/nodes/fixed_tf_broadcaster.py
+++ b/turtle_tf/nodes/fixed_tf_broadcaster.py
@@ -63,6 +63,6 @@ class FixedTFBroadcaster:
             self.pub_tf.publish(tfm)
 
 if __name__ == '__main__':
-    rospy.init_node('my_tf_broadcaster')
+    rospy.init_node('fixed_tf_broadcaster')
     tfb = FixedTFBroadcaster()
     rospy.spin()

--- a/turtle_tf/nodes/turtle_tf_broadcaster.py
+++ b/turtle_tf/nodes/turtle_tf_broadcaster.py
@@ -47,7 +47,7 @@ def handle_turtle_pose(msg, turtlename):
                      "world")
 
 if __name__ == '__main__':
-    rospy.init_node('tf_turtle')
+    rospy.init_node('turtle_tf_broadcaster')
     turtlename = rospy.get_param('~turtle')
     rospy.Subscriber('/%s/pose' % turtlename,
                      turtlesim.msg.Pose,

--- a/turtle_tf/nodes/turtle_tf_listener.py
+++ b/turtle_tf/nodes/turtle_tf_listener.py
@@ -39,7 +39,7 @@ import geometry_msgs.msg
 import turtlesim.srv
 
 if __name__ == '__main__':
-    rospy.init_node('tf_turtle')
+    rospy.init_node('turtle_tf_listener')
 
     listener = tf.TransformListener()
 

--- a/turtle_tf/nodes/turtle_tf_listener_wait.py
+++ b/turtle_tf/nodes/turtle_tf_listener_wait.py
@@ -39,7 +39,7 @@ import geometry_msgs.msg
 import turtlesim.srv
 
 if __name__ == '__main__':
-    rospy.init_node('tf_turtle')
+    rospy.init_node('turtle_tf_listener_wait')
 
     listener = tf.TransformListener()
 

--- a/turtle_tf/nodes/turtle_tf_message_broadcaster.py
+++ b/turtle_tf/nodes/turtle_tf_message_broadcaster.py
@@ -54,7 +54,7 @@ class PointPublisher:
         self.pub = rospy.Publisher('turtle_point_stamped', PointStamped, queue_size=1)
 
 if __name__ == '__main__':
-    rospy.init_node('tf_turtle_stamped_msg_publisher')
+    rospy.init_node('turtle_tf_msg_broadcaster')
     rospy.wait_for_service('spawn')
     spawner = rospy.ServiceProxy('spawn', turtlesim.srv.Spawn)
     spawner(4, 2, 0, 'turtle3')

--- a/turtle_tf2/nodes/dynamic_tf2_broadcaster.py
+++ b/turtle_tf2/nodes/dynamic_tf2_broadcaster.py
@@ -36,29 +36,32 @@ import tf2_ros
 import geometry_msgs.msg
 import math
 
-if __name__ == '__ STATIC main__':
-    rospy.init_node('my_tf2_broadcaster')
-    br = tf2_ros.TransformBroadcaster()
-    t = geometry_msgs.msg.TransformStamped()
+# Corresponds to adding a fixed frame described here in Section 6:
+# http://wiki.ros.org/tf2/Tutorials/Adding%20a%20frame%20%28Python%29
+#
+# if __name__ == '__ STATIC main__':
+#     rospy.init_node('dynamic_tf2_broadcaster')
+#     br = tf2_ros.TransformBroadcaster()
+#     t = geometry_msgs.msg.TransformStamped()
 
-    t.header.frame_id = "turtle1"
-    t.child_frame_id = "carrot1"
-    t.transform.translation.x = 0.0
-    t.transform.translation.y = 2.0
-    t.transform.translation.z = 0.0
-    t.transform.rotation.x = 0.0
-    t.transform.rotation.y = 0.0
-    t.transform.rotation.z = 0.0
-    t.transform.rotation.w = 1.0
+#     t.header.frame_id = "turtle1"
+#     t.child_frame_id = "carrot1"
+#     t.transform.translation.x = 0.0
+#     t.transform.translation.y = 2.0
+#     t.transform.translation.z = 0.0
+#     t.transform.rotation.x = 0.0
+#     t.transform.rotation.y = 0.0
+#     t.transform.rotation.z = 0.0
+#     t.transform.rotation.w = 1.0
 
-    rate = rospy.Rate(10.0)
-    while not rospy.is_shutdown():
-        t.header.stamp = rospy.Time.now()
-        br.sendTransform(t)
-        rate.sleep()
+#     rate = rospy.Rate(10.0)
+#     while not rospy.is_shutdown():
+#         t.header.stamp = rospy.Time.now()
+#         br.sendTransform(t)
+#         rate.sleep()
 
 if __name__ == '__main__':
-    rospy.init_node('my_tf2_broadcaster')
+    rospy.init_node('dynamic_tf2_broadcaster')
     br = tf2_ros.TransformBroadcaster()
     t = geometry_msgs.msg.TransformStamped()
 

--- a/turtle_tf2/nodes/fixed_tf2_broadcaster.py
+++ b/turtle_tf2/nodes/fixed_tf2_broadcaster.py
@@ -63,7 +63,7 @@ class FixedTFBroadcaster:
             self.pub_tf.publish(tfm)
 
 if __name__ == '__main__':
-    rospy.init_node('my_tf2_broadcaster')
+    rospy.init_node('fixed_tf2_broadcaster')
     tfb = FixedTFBroadcaster()
 
     rospy.spin()

--- a/turtle_tf2/nodes/turtle_tf2_broadcaster.py
+++ b/turtle_tf2/nodes/turtle_tf2_broadcaster.py
@@ -61,7 +61,7 @@ def handle_turtle_pose(msg, turtlename):
     br.sendTransform(t)
 
 if __name__ == '__main__':
-    rospy.init_node('tf_turtle')
+    rospy.init_node('turtle_tf2_broadcaster')
     turtlename = rospy.get_param('~turtle')
     rospy.Subscriber('/%s/pose' % turtlename,
                      turtlesim.msg.Pose,

--- a/turtle_tf2/nodes/turtle_tf2_listener.py
+++ b/turtle_tf2/nodes/turtle_tf2_listener.py
@@ -39,7 +39,7 @@ import geometry_msgs.msg
 import turtlesim.srv
 
 if __name__ == '__main__':
-    rospy.init_node('tf2_turtle')
+    rospy.init_node('turtle_tf2_listener')
 
     tfBuffer = tf2_ros.Buffer()
     listener = tf2_ros.TransformListener(tfBuffer)

--- a/turtle_tf2/nodes/turtle_tf2_listener_wait.py
+++ b/turtle_tf2/nodes/turtle_tf2_listener_wait.py
@@ -39,7 +39,7 @@ import geometry_msgs.msg
 import turtlesim.srv
 
 if __name__ == '__main__':
-    rospy.init_node('tf2_turtle')
+    rospy.init_node('turtle_tf2_listener_wait')
 
     tfBuffer = tf2_ros.Buffer()
     listener = tf2_ros.TransformListener(tfBuffer)

--- a/turtle_tf2/nodes/turtle_tf2_message_broadcaster.py
+++ b/turtle_tf2/nodes/turtle_tf2_message_broadcaster.py
@@ -54,7 +54,7 @@ class PointPublisher:
         self.pub = rospy.Publisher('turtle_point_stamped', PointStamped, queue_size=1)
 
 if __name__ == '__main__':
-    rospy.init_node('tf2_turtle_stamped_msg_publisher')
+    rospy.init_node('turtle_tf2_msg_broadcaster')
     rospy.wait_for_service('spawn')
     spawner = rospy.ServiceProxy('spawn', turtlesim.srv.Spawn)
     spawner(4, 2, 0, 'turtle3')


### PR DESCRIPTION
…mes for simplicity

Pretty straightforward:

- node names now match filenames

- I left the top code in `turtle_tf2/nodes/dynamic_tf2_broadcaster.py` commented out as it highlights a different method of publishing a static frame (Section 6) vs. the initial way (Section 3).

This attempts to address [ros/geometry2 issue 243](https://github.com/ros/geometry2/issues/243#issuecomment-313240483).