### PR TITLE
[noetic] Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/geometry_tutorials/CMakeLists.txt
+++ b/geometry_tutorials/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(geometry_tutorials)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/turtle_tf/CMakeLists.txt
+++ b/turtle_tf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(turtle_tf)
 
 ## Find dependencies

--- a/turtle_tf2/CMakeLists.txt
+++ b/turtle_tf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(turtle_tf2)
 ## Find dependencies
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

Maybe this should be targeted at a `kinetic-devel` or `noetic-devel` branch since 3.0.2 is greater than the minimum version supported by ROS Indigo?

Signed-off-by: ahcorde <ahcorde@gmail.com>