### PR TITLE
WIP: Add transformPose, transform to tutorials

### DIFF
--- a/turtle_tf/nodes/turtle_tf_listener.py
+++ b/turtle_tf/nodes/turtle_tf_listener.py
@@ -49,10 +49,20 @@ if __name__ == '__main__':
 
     turtle_vel = rospy.Publisher('turtle2/cmd_vel', geometry_msgs.msg.Twist, queue_size=1)
 
+    turtle1_pose = geometry_msgs.msg.PoseStamped()
+    turtle1_pose.header.frame_id = "turtle1"
+    turtle1_pose.pose.orientation.w = 1.0  # Neutral orientation
+    turtle1_pose_in_turtle2_frame = geometry_msgs.msg.PoseStamped()
+
     rate = rospy.Rate(10.0)
     while not rospy.is_shutdown():
         try:
             (trans, rot) = listener.lookupTransform('/turtle2', '/turtle1', rospy.Time())
+            turtle1_pose_in_turtle2_frame = listener.transformPose('turtle2', turtle1_pose)
+            ### None of the below alternatives work
+            # turtle1_pose_in_turtle2_frame = listener.transformPose("/turtle2", rospy.Time(), turtle1_pose, "world", turtle1_pose_in_turtle2_frame)
+            # turtle1_pose_in_turtle2_frame = listener.transformPose("/turtle2", rospy.Time(), turtle1_pose, "world")
+            # turtle1_pose_in_turtle2_frame = listener.transformPose("/turtle2", rospy.Time(), turtle1_pose)
         except (tf.LookupException, tf.ConnectivityException, tf.ExtrapolationException):
             continue
 
@@ -62,5 +72,7 @@ if __name__ == '__main__':
         msg.linear.x = linear
         msg.angular.z = angular
         turtle_vel.publish(msg)
+
+        # rospy.loginfo("Turtle2 sees turtle1 at x: %2f, y:  %2f", turtle1_pose_in_turtle2_frame.pose.position.x, turtle1_pose_in_turtle2_frame.pose.position.y)
 
         rate.sleep()

--- a/turtle_tf/src/turtle_tf_listener.cpp
+++ b/turtle_tf/src/turtle_tf_listener.cpp
@@ -1,5 +1,6 @@
 #include <ros/ros.h>
 #include <tf/transform_listener.h>
+#include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/Twist.h>
 #include <turtlesim/Spawn.h>
 
@@ -22,9 +23,16 @@ int main(int argc, char** argv){
   ros::Rate rate(10.0);
   while (node.ok()){
     tf::StampedTransform transform;
+
+    geometry_msgs::PoseStamped turtle1_pose, turtle1_pose_in_turtle2_frame;
+    turtle1_pose.header.frame_id = "turtle1";
+    turtle1_pose.pose.orientation.w = 1.0;  // Neutral orientation
+
     try{
       listener.lookupTransform("/turtle2", "/turtle1",
                                ros::Time(0), transform);
+      listener.transformPose("/turtle2", ros::Time(0), turtle1_pose, "world", turtle1_pose_in_turtle2_frame);
+      // listener.transformPose("/turtle2", turtle1_pose, turtle1_pose_in_turtle2_frame);
     }
     catch (tf::TransformException &ex) {
       ROS_ERROR("%s",ex.what());
@@ -38,6 +46,8 @@ int main(int argc, char** argv){
     vel_msg.linear.x = 0.5 * sqrt(pow(transform.getOrigin().x(), 2) +
                                   pow(transform.getOrigin().y(), 2));
     turtle_vel.publish(vel_msg);
+
+    // ROS_INFO_STREAM("Turtle2 sees turtle1 at x: " << turtle1_pose_in_turtle2_frame.pose.position.x << ", y: " << turtle1_pose_in_turtle2_frame.pose.position.y);
 
     rate.sleep();
   }

--- a/turtle_tf2/nodes/turtle_tf2_listener.py
+++ b/turtle_tf2/nodes/turtle_tf2_listener.py
@@ -51,10 +51,19 @@ if __name__ == '__main__':
 
     turtle_vel = rospy.Publisher('%s/cmd_vel' % turtle_name, geometry_msgs.msg.Twist, queue_size=1)
 
+    turtle1_pose = geometry_msgs.msg.PoseStamped()
+    turtle1_pose.header.frame_id = "turtle1"
+    turtle1_pose.pose.orientation.w = 1.0  # Neutral orientation
+    turtle1_pose_in_turtle2_frame = geometry_msgs.msg.PoseStamped()
+
     rate = rospy.Rate(10.0)
     while not rospy.is_shutdown():
         try:
             trans = tfBuffer.lookup_transform(turtle_name, 'turtle1', rospy.Time())
+            # None of the below work
+            turtle1_pose_in_turtle2_frame = tfBuffer.transform(turtle1_pose, "/turtle2", rospy.Time(), "world")
+            # turtle1_pose_in_turtle2_frame = tfBuffer.transform(turtle1_pose, turtle1_pose_in_turtle2_frame, "/turtle2", rospy.Time(), "world")
+            # turtle1_pose_in_turtle2_frame = tfBuffer.transform('turtle2', turtle1_pose)
         except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException):
             rate.sleep()
             continue
@@ -65,5 +74,7 @@ if __name__ == '__main__':
         msg.linear.x = 0.5 * math.sqrt(trans.transform.translation.x ** 2 + trans.transform.translation.y ** 2)
 
         turtle_vel.publish(msg)
+
+        rospy.loginfo("Turtle2 sees turtle1 at x: %2f, y:  %2f", turtle1_pose_in_turtle2_frame.pose.position.x, turtle1_pose_in_turtle2_frame.pose.position.y)
 
         rate.sleep()

--- a/turtle_tf2/src/turtle_tf2_listener.cpp
+++ b/turtle_tf2/src/turtle_tf2_listener.cpp
@@ -1,5 +1,6 @@
 #include <ros/ros.h>
 #include <tf2_ros/transform_listener.h>
+#include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <geometry_msgs/Twist.h>
 #include <turtlesim/Spawn.h>
@@ -25,12 +26,19 @@ int main(int argc, char** argv){
   tf2_ros::Buffer tfBuffer;
   tf2_ros::TransformListener tfListener(tfBuffer);
 
+  geometry_msgs::PoseStamped turtle1_pose, turtle1_pose_in_turtle2_frame;
+  turtle1_pose.header.frame_id = "turtle1";
+  turtle1_pose.pose.orientation.w = 1.0;  // Neutral orientation
+
   ros::Rate rate(10.0);
   while (node.ok()){
     geometry_msgs::TransformStamped transformStamped;
     try{
       transformStamped = tfBuffer.lookupTransform("turtle2", "turtle1",
                                ros::Time(0));
+      // Neither of the below work
+      turtle1_pose_in_turtle2_frame = tfBuffer.transform(turtle1_pose, turtle1_pose_in_turtle2_frame, "/turtle2", ros::Time(0), "world");
+      // turtle1_pose_in_turtle2_frame = tfBuffer.transform(turtle1_pose, "/turtle2");
     }
     catch (tf2::TransformException &ex) {
       ROS_WARN("%s",ex.what());
@@ -45,6 +53,8 @@ int main(int argc, char** argv){
     vel_msg.linear.x = 0.5 * sqrt(pow(transformStamped.transform.translation.x, 2) +
                                   pow(transformStamped.transform.translation.y, 2));
     turtle_vel.publish(vel_msg);
+
+    // ROS_INFO_STREAM("Turtle2 sees turtle1 at x: " << turtle1_pose_in_turtle2_frame.pose.position.x << ", y: " << turtle1_pose_in_turtle2_frame.pose.position.y);
     
     rate.sleep();
   }


### PR DESCRIPTION
As discussed [here](https://answers.ros.org/question/374986/how-to-use-transformpose-in-python-with-time0-most-recent-common-time/?comment=375052#post-id-375052), these tutorials were missing the most convenient interface. I tried adding them in this PR, but I can't get the [TF2 API](http://docs.ros.org/en/api/tf2_ros/html/c++/classtf2__ros_1_1BufferInterface.html#a9406dc8d32c3a50e026859b587587769) to work. Also, I don't see a way to pass `Time(0)` to `transformPose` in the [TF1 Python API](http://docs.ros.org/en/melodic/api/tf/html/python/tf_python.html).

Trying to compile this PR gives me a linker error, but I don't see where I am not matching the [template](http://docs.ros.org/en/api/tf2_ros/html/c++/classtf2__ros_1_1BufferInterface.html#a9406dc8d32c3a50e026859b587587769):

```
Errors     << turtle_tf2:make /root/catkin_ws/logs/turtle_tf2/build.make.012.log                                
CMakeFiles/turtle_tf2_listener.dir/src/turtle_tf2_listener.cpp.o: In function `geometry_msgs::PoseStamped_<std::allocator<void> >& tf2_ros::BufferInterface::transform<geometry_msgs::PoseStamped_<std::allocator<void> > >(geometry_msgs::PoseStamped_<std::allocator<void> > const&, geometry_msgs::PoseStamped_<std::allocator<void> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, ros::Time const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, ros::Duration) const':
turtle_tf2_listener.cpp:(.text._ZNK7tf2_ros15BufferInterface9transformIN13geometry_msgs12PoseStamped_ISaIvEEEEERT_RKS6_S7_RKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKN3ros4TimeESH_NSI_8DurationE[_ZNK7tf2_ros15BufferInterface9transformIN13geometry_msgs12PoseStamped_ISaIvEEEEERT_RKS6_S7_RKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKN3ros4TimeESH_NSI_8DurationE]+0x7f): undefined reference to `ros::Time const& tf2::getTimestamp<geometry_msgs::PoseStamped_<std::allocator<void> > >(geometry_msgs::PoseStamped_<std::allocator<void> > const&)'
turtle_tf2_listener.cpp:(.text._ZNK7tf2_ros15BufferInterface9transformIN13geometry_msgs12PoseStamped_ISaIvEEEEERT_RKS6_S7_RKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKN3ros4TimeESH_NSI_8DurationE[_ZNK7tf2_ros15BufferInterface9transformIN13geometry_msgs12PoseStamped_ISaIvEEEEERT_RKS6_S7_RKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKN3ros4TimeESH_NSI_8DurationE]+0x91): undefined reference to `std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const& tf2::getFrameId<geometry_msgs::PoseStamped_<std::allocator<void> > >(geometry_msgs::PoseStamped_<std::allocator<void> > const&)'
turtle_tf2_listener.cpp:(.text._ZNK7tf2_ros15BufferInterface9transformIN13geometry_msgs12PoseStamped_ISaIvEEEEERT_RKS6_S7_RKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKN3ros4TimeESH_NSI_8DurationE[_ZNK7tf2_ros15BufferInterface9transformIN13geometry_msgs12PoseStamped_ISaIvEEEEERT_RKS6_S7_RKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERKN3ros4TimeESH_NSI_8DurationE]+0xea): undefined reference to `void tf2::doTransform<geometry_msgs::PoseStamped_<std::allocator<void> > >(geometry_msgs::PoseStamped_<std::allocator<void> > const&, geometry_msgs::PoseStamped_<std::allocator<void> >&, geometry_msgs::TransformStamped_<std::allocator<void> > const&)'
collect2: error: ld returned 1 exit status
make[2]: *** [/root/catkin_ws/devel/.private/turtle_tf2/lib/turtle_tf2/turtle_tf2_listener] Error 1
make[1]: *** [CMakeFiles/turtle_tf2_listener.dir/all] Error 2
make: *** [all] Error 2
```

This affects the following tutorial pages, which I will update after this PR is merged:  
http://wiki.ros.org/tf/Tutorials/Writing%20a%20tf%20listener%20%28C%2B%2B%29  
http://wiki.ros.org/tf/Tutorials/Writing%20a%20tf%20listener%20%28Python%29  
http://wiki.ros.org/tf2/Tutorials/Writing%20a%20tf2%20listener%20%28C%2B%2B%29  
http://wiki.ros.org/tf2/Tutorials/Writing%20a%20tf2%20listener%20%28Python%29  