### PR TITLE
Add fixed and dynamic frame broadcaster nodes

### DIFF
--- a/turtle_tf2_py/launch/turtle_tf2_demo.launch.py
+++ b/turtle_tf2_py/launch/turtle_tf2_demo.launch.py
@@ -13,11 +13,18 @@
 # limitations under the License.
 
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'target_frame', default_value='turtle1',
+            description='Target frame name.'
+        ),
         Node(
             package='turtlesim',
             executable='turtlesim_node',
@@ -42,6 +49,9 @@ def generate_launch_description():
         Node(
             package='turtle_tf2_py',
             executable='turtle_tf2_listener',
-            name='listener'
+            name='listener',
+            parameters=[
+                {'target_frame': LaunchConfiguration('target_frame')}
+            ]
         ),
     ])

--- a/turtle_tf2_py/launch/turtle_tf2_dynamic_frame_demo.launch.py
+++ b/turtle_tf2_py/launch/turtle_tf2_dynamic_frame_demo.launch.py
@@ -28,6 +28,8 @@ def generate_launch_description():
         PythonLaunchDescriptionSource([os.path.join(
             get_package_share_directory('turtle_tf2_py'), 'launch'),
             '/turtle_tf2_demo.launch.py']),
+
+        launch_arguments={'target_frame': 'carrot1'}.items(),
         )
 
     return LaunchDescription([

--- a/turtle_tf2_py/launch/turtle_tf2_dynamic_frame_demo.launch.py
+++ b/turtle_tf2_py/launch/turtle_tf2_dynamic_frame_demo.launch.py
@@ -28,7 +28,6 @@ def generate_launch_description():
         PythonLaunchDescriptionSource([os.path.join(
             get_package_share_directory('turtle_tf2_py'), 'launch'),
             '/turtle_tf2_demo.launch.py']),
-
         launch_arguments={'target_frame': 'carrot1'}.items(),
         )
 

--- a/turtle_tf2_py/launch/turtle_tf2_dynamic_frame_demo.launch.py
+++ b/turtle_tf2_py/launch/turtle_tf2_dynamic_frame_demo.launch.py
@@ -1,0 +1,39 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    demo_nodes = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('turtle_tf2_py'), 'launch'), '/turtle_tf2_demo.launch.py']),
+        )
+
+    return LaunchDescription([
+        demo_nodes,
+        Node(
+            package='turtle_tf2_py',
+            executable='dynamic_frame_tf2_broadcaster',
+            name='dynamic_broadcaster',
+        ),
+    ])

--- a/turtle_tf2_py/launch/turtle_tf2_dynamic_frame_demo.launch.py
+++ b/turtle_tf2_py/launch/turtle_tf2_dynamic_frame_demo.launch.py
@@ -26,7 +26,8 @@ from launch_ros.actions import Node
 def generate_launch_description():
     demo_nodes = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('turtle_tf2_py'), 'launch'), '/turtle_tf2_demo.launch.py']),
+            get_package_share_directory('turtle_tf2_py'), 'launch'),
+            '/turtle_tf2_demo.launch.py']),
         )
 
     return LaunchDescription([

--- a/turtle_tf2_py/launch/turtle_tf2_fixed_frame_demo.launch.py
+++ b/turtle_tf2_py/launch/turtle_tf2_fixed_frame_demo.launch.py
@@ -1,0 +1,39 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    demo_nodes = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([os.path.join(
+            get_package_share_directory('turtle_tf2_py'), 'launch'), '/turtle_tf2_demo.launch.py']),
+        )
+
+    return LaunchDescription([
+        demo_nodes,
+        Node(
+            package='turtle_tf2_py',
+            executable='fixed_frame_tf2_broadcaster',
+            name='fixed_broadcaster',
+        ),
+    ])

--- a/turtle_tf2_py/launch/turtle_tf2_fixed_frame_demo.launch.py
+++ b/turtle_tf2_py/launch/turtle_tf2_fixed_frame_demo.launch.py
@@ -28,6 +28,8 @@ def generate_launch_description():
         PythonLaunchDescriptionSource([os.path.join(
             get_package_share_directory('turtle_tf2_py'), 'launch'),
             '/turtle_tf2_demo.launch.py']),
+
+        launch_arguments={'target_frame': 'carrot1'}.items(),
         )
 
     return LaunchDescription([

--- a/turtle_tf2_py/launch/turtle_tf2_fixed_frame_demo.launch.py
+++ b/turtle_tf2_py/launch/turtle_tf2_fixed_frame_demo.launch.py
@@ -28,7 +28,6 @@ def generate_launch_description():
         PythonLaunchDescriptionSource([os.path.join(
             get_package_share_directory('turtle_tf2_py'), 'launch'),
             '/turtle_tf2_demo.launch.py']),
-
         launch_arguments={'target_frame': 'carrot1'}.items(),
         )
 

--- a/turtle_tf2_py/launch/turtle_tf2_fixed_frame_demo.launch.py
+++ b/turtle_tf2_py/launch/turtle_tf2_fixed_frame_demo.launch.py
@@ -26,7 +26,8 @@ from launch_ros.actions import Node
 def generate_launch_description():
     demo_nodes = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([os.path.join(
-            get_package_share_directory('turtle_tf2_py'), 'launch'), '/turtle_tf2_demo.launch.py']),
+            get_package_share_directory('turtle_tf2_py'), 'launch'),
+            '/turtle_tf2_demo.launch.py']),
         )
 
     return LaunchDescription([

--- a/turtle_tf2_py/setup.py
+++ b/turtle_tf2_py/setup.py
@@ -32,9 +32,11 @@ setup(
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [
+            'static_turtle_tf2_broadcaster = turtle_tf2_py.static_turtle_tf2_broadcaster:main',
             'turtle_tf2_broadcaster = turtle_tf2_py.turtle_tf2_broadcaster:main',
             'turtle_tf2_listener = turtle_tf2_py.turtle_tf2_listener:main',
-            'static_turtle_tf2_broadcaster = turtle_tf2_py.static_turtle_tf2_broadcaster:main',
+            'fixed_frame_tf2_broadcaster = turtle_tf2_py.fixed_frame_tf2_broadcaster:main',
+            'dynamic_frame_tf2_broadcaster = turtle_tf2_py.dynamic_frame_tf2_broadcaster:main',
         ],
     },
 )

--- a/turtle_tf2_py/turtle_tf2_py/dynamic_frame_tf2_broadcaster.py
+++ b/turtle_tf2_py/turtle_tf2_py/dynamic_frame_tf2_broadcaster.py
@@ -1,0 +1,59 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+from geometry_msgs.msg import TransformStamped
+
+import rclpy
+from rclpy.node import Node
+
+from tf2_ros import TransformBroadcaster
+
+
+class DynamicFrameBroadcaster(Node):
+
+    def __init__(self):
+        super().__init__('dynamic_frame_tf2_broadcaster')
+        self.br = TransformBroadcaster(self)
+        self.timer = self.create_timer(0.1, self.broadcast_timer_callback)
+
+    def broadcast_timer_callback(self):
+        seconds, _ = self.get_clock().now().seconds_nanoseconds()
+        x = seconds * math.pi
+
+        t = TransformStamped()
+        t.header.stamp = self.get_clock().now().to_msg()
+        t.header.frame_id = 'turtle1'
+        t.child_frame_id = 'carrot1'
+        t.transform.translation.x = 10 * math.sin(x)
+        t.transform.translation.y = 10 * math.cos(x)
+        t.transform.translation.z = 0.0
+        t.transform.rotation.x = 0.0
+        t.transform.rotation.y = 0.0
+        t.transform.rotation.z = 0.0
+        t.transform.rotation.w = 1.0
+
+        self.br.sendTransform(t)
+
+
+def main():
+    rclpy.init()
+    node = DynamicFrameBroadcaster()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+
+    rclpy.shutdown()

--- a/turtle_tf2_py/turtle_tf2_py/fixed_frame_tf2_broadcaster.py
+++ b/turtle_tf2_py/turtle_tf2_py/fixed_frame_tf2_broadcaster.py
@@ -1,0 +1,54 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from geometry_msgs.msg import TransformStamped
+
+import rclpy
+from rclpy.node import Node
+
+from tf2_ros import TransformBroadcaster
+
+
+class FixedFrameBroadcaster(Node):
+
+    def __init__(self):
+        super().__init__('fixed_frame_tf2_broadcaster')
+        self.br = TransformBroadcaster(self)
+        self.timer = self.create_timer(0.1, self.broadcast_timer_callback)
+
+    def broadcast_timer_callback(self):
+        t = TransformStamped()
+        t.header.stamp = self.get_clock().now().to_msg()
+        t.header.frame_id = 'turtle1'
+        t.child_frame_id = 'carrot1'
+        t.transform.translation.x = 0.0
+        t.transform.translation.y = 2.0
+        t.transform.translation.z = 0.0
+        t.transform.rotation.x = 0.0
+        t.transform.rotation.y = 0.0
+        t.transform.rotation.z = 0.0
+        t.transform.rotation.w = 1.0
+
+        self.br.sendTransform(t)
+
+
+def main():
+    rclpy.init()
+    node = FixedFrameBroadcaster()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+
+    rclpy.shutdown()

--- a/turtle_tf2_py/turtle_tf2_py/turtle_tf2_listener.py
+++ b/turtle_tf2_py/turtle_tf2_py/turtle_tf2_listener.py
@@ -32,6 +32,11 @@ class FrameListener(Node):
     def __init__(self):
         super().__init__('turtle_tf2_frame_listener')
 
+        # Declare and acquire `target_frame` parameter
+        self.declare_parameter('target_frame', 'turtle1')
+        self.target_frame = self.get_parameter(
+            'target_frame').get_parameter_value().string_value
+
         self._tf_buffer = Buffer()
         self._tf_listener = TransformListener(self._tf_buffer, self)
 
@@ -59,11 +64,13 @@ class FrameListener(Node):
         self._output_timer = self.create_timer(1.0, self.on_timer)
 
     def on_timer(self):
-        from_frame_rel = 'turtle1'
+        # Store frame names in variables that will be used to
+        # compute transformations
+        from_frame_rel = self.target_frame
         to_frame_rel = 'turtle2'
 
-        # Look up for the transformation between turtle1 and turtle2 frames
-        # and send velocity commands for turtle2 to reach turtle1
+        # Look up for the transformation between target_frame and turtle2 frames
+        # and send velocity commands for turtle2 to reach target_frame
         try:
             now = rclpy.time.Time()
             trans = self._tf_buffer.lookup_transform(


### PR DESCRIPTION
Add fixed and dynamic frame broadcaster nodes that will be used in the upcoming Adding a Frame (Python) tutorial.

Signed-off-by: Shyngyskhan Abilkassov abilkasov@gmail.com