### PR TITLE
Remove the dependency on tf_transformations.

### DIFF
--- a/turtle_tf2_py/package.xml
+++ b/turtle_tf2_py/package.xml
@@ -9,14 +9,15 @@
   <maintainer email="alejandro@openrobotics.org">Alejandro Hernández Cordero</maintainer>
   <maintainer email="audrow@openrobotics.org">Audrow Nash</maintainer>
   <license>Apache License, Version 2.0</license>
+  <license>BSD</license>
 
   <author email="abilkasov@gmail.com">Shyngyskhan Abilkassov</author>
 
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>tf_transformations</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>turtlesim</exec_depend>
 

--- a/turtle_tf2_py/turtle_tf2_py/static_turtle_tf2_broadcaster.py
+++ b/turtle_tf2_py/turtle_tf2_py/static_turtle_tf2_broadcaster.py
@@ -12,16 +12,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import sys
 
 from geometry_msgs.msg import TransformStamped
+
+import numpy as np
 
 import rclpy
 from rclpy.node import Node
 
 from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
 
-import tf_transformations
+
+# This function is a stripped down version of the code in
+# https://github.com/matthew-brett/transforms3d/blob/f185e866ecccb66c545559bc9f2e19cb5025e0ab/transforms3d/euler.py
+# Besides simplifying it, this version also inverts the order to return x,y,z,w, which is
+# the way that ROS prefers it.
+def quaternion_from_euler(ai, aj, ak):
+    ai /= 2.0
+    aj /= 2.0
+    ak /= 2.0
+    ci = math.cos(ai)
+    si = math.sin(ai)
+    cj = math.cos(aj)
+    sj = math.sin(aj)
+    ck = math.cos(ak)
+    sk = math.sin(ak)
+    cc = ci*ck
+    cs = ci*sk
+    sc = si*ck
+    ss = si*sk
+
+    q = np.empty((4, ))
+    q[0] = cj*sc - sj*cs
+    q[1] = cj*ss + sj*cc
+    q[2] = cj*cs - sj*sc
+    q[3] = cj*cc + sj*ss
+
+    return q
 
 
 class StaticFramePublisher(Node):
@@ -49,7 +78,7 @@ class StaticFramePublisher(Node):
         static_transformStamped.transform.translation.x = float(sys.argv[2])
         static_transformStamped.transform.translation.y = float(sys.argv[3])
         static_transformStamped.transform.translation.z = float(sys.argv[4])
-        quat = tf_transformations.quaternion_from_euler(
+        quat = quaternion_from_euler(
             float(sys.argv[5]), float(sys.argv[6]), float(sys.argv[7]))
         static_transformStamped.transform.rotation.x = quat[0]
         static_transformStamped.transform.rotation.y = quat[1]

--- a/turtle_tf2_py/turtle_tf2_py/turtle_tf2_broadcaster.py
+++ b/turtle_tf2_py/turtle_tf2_py/turtle_tf2_broadcaster.py
@@ -12,16 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 from geometry_msgs.msg import TransformStamped
+
+import numpy as np
 
 import rclpy
 from rclpy.node import Node
 
 from tf2_ros import TransformBroadcaster
 
-import tf_transformations
-
 from turtlesim.msg import Pose
+
+
+# This function is a stripped down version of the code in
+# https://github.com/matthew-brett/transforms3d/blob/f185e866ecccb66c545559bc9f2e19cb5025e0ab/transforms3d/euler.py
+# Besides simplifying it, this version also inverts the order to return x,y,z,w, which is
+# the way that ROS prefers it.
+def quaternion_from_euler(ai, aj, ak):
+    ai /= 2.0
+    aj /= 2.0
+    ak /= 2.0
+    ci = math.cos(ai)
+    si = math.sin(ai)
+    cj = math.cos(aj)
+    sj = math.sin(aj)
+    ck = math.cos(ak)
+    sk = math.sin(ak)
+    cc = ci*ck
+    cs = ci*sk
+    sc = si*ck
+    ss = si*sk
+
+    q = np.empty((4, ))
+    q[0] = cj*sc - sj*cs
+    q[1] = cj*ss + sj*cc
+    q[2] = cj*cs - sj*sc
+    q[3] = cj*cc + sj*ss
+
+    return q
 
 
 class FramePublisher(Node):
@@ -64,7 +94,7 @@ class FramePublisher(Node):
         # For the same reason, turtle can only rotate around one axis
         # and this why we set rotation in x and y to 0 and obtain
         # rotation in z axis from the message
-        q = tf_transformations.quaternion_from_euler(0, 0, msg.theta)
+        q = quaternion_from_euler(0, 0, msg.theta)
         t.transform.rotation.x = q[0]
         t.transform.rotation.y = q[1]
         t.transform.rotation.z = q[2]


### PR DESCRIPTION
That way we don't have to install a non-standard library
(tf_transformations) that depends on a non-packaged pip
package (transforms3d) for the tutorials to work.

Note well that the function is copied twice, once in
static_turtle_tf2_broadcaster.py and once in turtle_tf2_broadcaster.py.
This is by design, as these files are used as standalone
examples in the ROS 2 tutorials.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>