### PR TITLE
Cleanup CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          linter: [copyright, cpplint, cppcheck, uncrustify]
+          linter: [copyright, cpplint, uncrustify]
     steps:
     - uses: actions/checkout@v2
     - uses: ros-tooling/setup-ros@v0.3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,14 +5,16 @@ on:
 jobs:
   ament_lint:
     name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:jammy
     strategy:
       fail-fast: false
       matrix:
           linter: [copyright, flake8, pep257]
     steps:
     - uses: actions/checkout@v2
-    - uses: ros-tooling/setup-ros@v0.2
+    - uses: ros-tooling/setup-ros@v0.3
       with:
         required-ros-distributions: rolling
     - uses: ros-tooling/action-ros-lint@v0.1
@@ -22,14 +24,16 @@ jobs:
         package-name: turtle_tf2_py
   ament_lint_cpp:
     name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:jammy
     strategy:
       fail-fast: false
       matrix:
           linter: [copyright, cpplint, cppcheck, uncrustify]
     steps:
     - uses: actions/checkout@v2
-    - uses: ros-tooling/setup-ros@v0.2
+    - uses: ros-tooling/setup-ros@v0.3
       with:
         required-ros-distributions: rolling
     - uses: ros-tooling/action-ros-lint@v0.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
   build_and_test_source_rolling:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-latest
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
     - name: Build and run tests
       id: action-ros-ci
@@ -19,7 +19,33 @@ jobs:
           turtle_tf2_py
           turtle_tf2_cpp
         target-ros2-distro: rolling
-        vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+        vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
+        colcon-defaults: |
+          {
+            "build": {
+              "cmake-args": [
+                "-DCMAKE_CXX_FLAGS=\"-Werror\""
+              ]
+            },
+            "test": {
+              "ctest-args": ["-LE", "xfail"],
+              "pytest-args": ["-m", "not xfail"]
+            }
+          }
+  build_and_test_source_humble:
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
+    steps:
+    - name: Build and run tests
+      id: action-ros-ci
+      uses: ros-tooling/action-ros-ci@v0.2
+      with:
+        package-name: |
+          turtle_tf2_py
+          turtle_tf2_cpp
+        target-ros2-distro: humble
+        vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/humble/ros2.repos
         colcon-defaults: |
           {
             "build": {
@@ -87,7 +113,7 @@ jobs:
   build_and_test_binaries_rolling:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-focal-latest
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
     - name: Build and run tests
       id: action-ros-ci
@@ -97,6 +123,31 @@ jobs:
           turtle_tf2_py
           turtle_tf2_cpp
         target-ros2-distro: rolling
+        colcon-defaults: |
+          {
+            "build": {
+              "cmake-args": [
+                "-DCMAKE_CXX_FLAGS=\"-Werror\""
+              ]
+            },
+            "test": {
+              "ctest-args": ["-LE", "xfail"],
+              "pytest-args": ["-m", "not xfail"]
+            }
+          }
+  build_and_test_binaries_humble:
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
+    steps:
+    - name: Build and run tests
+      id: action-ros-ci
+      uses: ros-tooling/action-ros-ci@v0.2
+      with:
+        package-name: |
+          turtle_tf2_py
+          turtle_tf2_cpp
+        target-ros2-distro: humble
         colcon-defaults: |
           {
             "build": {

--- a/turtle_tf2_cpp/CMakeLists.txt
+++ b/turtle_tf2_cpp/CMakeLists.txt
@@ -23,7 +23,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(turtlesim REQUIRED)
 
-if (TARGET tf2_geometry_msgs::tf2_geometry_msgs)
+if(TARGET tf2_geometry_msgs::tf2_geometry_msgs)
   get_target_property(_include_dirs tf2_geometry_msgs::tf2_geometry_msgs INTERFACE_INCLUDE_DIRECTORIES)
 else()
   set(_include_dirs ${tf2_geometry_msgs_INCLUDE_DIRS})

--- a/turtle_tf2_cpp/CMakeLists.txt
+++ b/turtle_tf2_cpp/CMakeLists.txt
@@ -23,9 +23,15 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(turtlesim REQUIRED)
 
+if (TARGET tf2_geometry_msgs::tf2_geometry_msgs)
+  get_target_property(_include_dirs tf2_geometry_msgs::tf2_geometry_msgs INTERFACE_INCLUDE_DIRECTORIES)
+else()
+  set(_include_dirs ${tf2_geometry_msgs_INCLUDE_DIRS})
+endif()
+
 find_file(TF2_CPP_HEADERS
   NAMES tf2_geometry_msgs.hpp
-  PATHS ${tf2_geometry_msgs_INCLUDE_DIRS}
+  PATHS ${_include_dirs}
   NO_CACHE
   PATH_SUFFIXES tf2_geometry_msgs
 )

--- a/turtle_tf2_cpp/src/dynamic_frame_tf2_broadcaster.cpp
+++ b/turtle_tf2_cpp/src/dynamic_frame_tf2_broadcaster.cpp
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <geometry_msgs/msg/transform_stamped.hpp>
-
-#include <rclcpp/rclcpp.hpp>
-#include <tf2_ros/transform_broadcaster.h>
-
+#include <chrono>
+#include <functional>
 #include <memory>
+
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2_ros/transform_broadcaster.h"
 
 using namespace std::chrono_literals;
 

--- a/turtle_tf2_cpp/src/fixed_frame_tf2_broadcaster.cpp
+++ b/turtle_tf2_cpp/src/fixed_frame_tf2_broadcaster.cpp
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <geometry_msgs/msg/transform_stamped.hpp>
-
-#include <rclcpp/rclcpp.hpp>
-#include <tf2_ros/transform_broadcaster.h>
-
+#include <chrono>
+#include <functional>
 #include <memory>
+
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2_ros/transform_broadcaster.h"
 
 using namespace std::chrono_literals;
 

--- a/turtle_tf2_cpp/src/static_turtle_tf2_broadcaster.cpp
+++ b/turtle_tf2_cpp/src/static_turtle_tf2_broadcaster.cpp
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <geometry_msgs/msg/transform_stamped.hpp>
-
-#include <rclcpp/rclcpp.hpp>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2_ros/static_transform_broadcaster.h>
-
 #include <memory>
 
-using std::placeholders::_1;
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2_ros/static_transform_broadcaster.h"
 
 class StaticFramePublisher : public rclcpp::Node
 {

--- a/turtle_tf2_cpp/src/turtle_tf2_broadcaster.cpp
+++ b/turtle_tf2_cpp/src/turtle_tf2_broadcaster.cpp
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <geometry_msgs/msg/transform_stamped.hpp>
-
-#include <rclcpp/rclcpp.hpp>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <turtlesim/msg/pose.hpp>
-
+#include <functional>
 #include <memory>
+#include <sstream>
 #include <string>
 
-using std::placeholders::_1;
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2/LinearMath/Quaternion.h"
+#include "tf2_ros/transform_broadcaster.h"
+#include "turtlesim/msg/pose.hpp"
 
 class FramePublisher : public rclcpp::Node
 {
@@ -46,7 +45,7 @@ public:
 
     subscription_ = this->create_subscription<turtlesim::msg::Pose>(
       topic_name, 10,
-      std::bind(&FramePublisher::handle_turtle_pose, this, _1));
+      std::bind(&FramePublisher::handle_turtle_pose, this, std::placeholders::_1));
   }
 
 private:

--- a/turtle_tf2_cpp/src/turtle_tf2_listener.cpp
+++ b/turtle_tf2_cpp/src/turtle_tf2_listener.cpp
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <geometry_msgs/msg/transform_stamped.hpp>
-#include <geometry_msgs/msg/twist.hpp>
-
-#include <rclcpp/rclcpp.hpp>
-#include <tf2/exceptions.h>
-#include <tf2_ros/transform_listener.h>
-#include <tf2_ros/buffer.h>
-#include <turtlesim/srv/spawn.hpp>
-
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <string>
 
-using std::placeholders::_1;
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2/exceptions.h"
+#include "tf2_ros/transform_listener.h"
+#include "tf2_ros/buffer.h"
+#include "turtlesim/srv/spawn.hpp"
+
 using namespace std::chrono_literals;
 
 class FrameListener : public rclcpp::Node

--- a/turtle_tf2_cpp/src/turtle_tf2_message_filter.cpp
+++ b/turtle_tf2_cpp/src/turtle_tf2_message_filter.cpp
@@ -12,23 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <geometry_msgs/msg/point_stamped.hpp>
-#include <message_filters/subscriber.h>
-
-#include <rclcpp/rclcpp.hpp>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/create_timer_ros.h>
-#include <tf2_ros/message_filter.h>
-#include <tf2_ros/transform_listener.h>
-#ifdef TF2_CPP_HEADERS
-  #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#else
-  #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#endif
-
 #include <chrono>
 #include <memory>
 #include <string>
+
+#include "geometry_msgs/msg/point_stamped.hpp"
+#include "message_filters/subscriber.h"
+#include "rclcpp/rclcpp.hpp"
+#include "tf2_ros/buffer.h"
+#include "tf2_ros/create_timer_ros.h"
+#include "tf2_ros/message_filter.h"
+#include "tf2_ros/transform_listener.h"
+#ifdef TF2_CPP_HEADERS
+  #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#else
+  #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#endif
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
This PR gets us to green CI on geometry_tutorials (for all of Foxy, Galactic, Humble, and Rolling).

To get there, we do the following:
1.  Fix up a warning when building on Humble and Rolling about the tf2_geometry_msgs header.  There was existing logic, but it didn't work properly on Humble/Rolling.
2. Fix up the header inclusion style so it works for both old cpplint (Foxy and Galactic) along with new one (Humble and Rolling).
3. Change the github actions for Rolling to use Ubuntu 22.04 in a container, as that is what Rolling targets.
4. Adds in Humble support to Github CI.
5. Skip cppcheck in the linting steps.  That's because on Ubuntu 22.04, the version of cppcheck is way too slow and `ament_cppcheck` has it disabled.  However, because of the way we disable it in `ament_cppcheck`, it returns a non-zero exit status, and that would cause the test to fail.  Instead, just skip it.