### PR TITLE
Fix a few more minor nitpicks.

### DIFF
--- a/turtle_tf2_cpp/CMakeLists.txt
+++ b/turtle_tf2_cpp/CMakeLists.txt
@@ -43,7 +43,6 @@ ament_target_dependencies(
   rclcpp
   tf2
   tf2_ros
-  turtlesim
 )
 
 add_executable(turtle_tf2_broadcaster src/turtle_tf2_broadcaster.cpp)
@@ -72,7 +71,6 @@ ament_target_dependencies(
   geometry_msgs
   rclcpp
   tf2_ros
-  turtlesim
 )
 
 add_executable(dynamic_frame_tf2_broadcaster src/dynamic_frame_tf2_broadcaster.cpp)
@@ -81,7 +79,6 @@ ament_target_dependencies(
   geometry_msgs
   rclcpp
   tf2_ros
-  turtlesim
 )
 
 add_executable(turtle_tf2_message_filter src/turtle_tf2_message_filter.cpp)
@@ -90,7 +87,6 @@ ament_target_dependencies(
   geometry_msgs
   message_filters
   rclcpp
-  tf2
   tf2_geometry_msgs
   tf2_ros
 )

--- a/turtle_tf2_cpp/src/turtle_tf2_message_filter.cpp
+++ b/turtle_tf2_cpp/src/turtle_tf2_message_filter.cpp
@@ -40,8 +40,7 @@ public:
     // Declare and acquire `target_frame` parameter
     target_frame_ = this->declare_parameter<std::string>("target_frame", "turtle1");
 
-    typedef std::chrono::duration<int> seconds_type;
-    seconds_type buffer_timeout(1);
+    std::chrono::duration<int> buffer_timeout(1);
 
     tf2_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
     // Create the timer interface before call to waitForTransform,

--- a/turtle_tf2_py/turtle_tf2_py/turtle_tf2_message_broadcaster.py
+++ b/turtle_tf2_py/turtle_tf2_py/turtle_tf2_message_broadcaster.py
@@ -56,9 +56,9 @@ class PointPublisher(Node):
                 # Note that x, y and theta are defined as floats in turtlesim/srv/Spawn
                 request = Spawn.Request()
                 request.name = 'turtle3'
-                request.x = float(4)
-                request.y = float(2)
-                request.theta = float(0)
+                request.x = 4.0
+                request.y = 2.0
+                request.theta = 0.0
                 # Call request
                 self.result = self.spawner.call_async(request)
                 self.turtle_spawning_service_ready = True


### PR DESCRIPTION
1.  Remove dependencies from the targets that don't need them.
2.  Remove a totally unnecessary typedef.
3.  Remove unnecessary casts to float.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>