### PR TITLE
Switch to using a context manager for rclpy initialization.

### DIFF
--- a/turtle_tf2_py/turtle_tf2_py/dynamic_frame_tf2_broadcaster.py
+++ b/turtle_tf2_py/turtle_tf2_py/dynamic_frame_tf2_broadcaster.py
@@ -17,6 +17,7 @@ import math
 from geometry_msgs.msg import TransformStamped
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from tf2_ros import TransformBroadcaster
@@ -49,11 +50,9 @@ class DynamicFrameBroadcaster(Node):
 
 
 def main():
-    rclpy.init()
-    node = DynamicFrameBroadcaster()
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init():
+            node = DynamicFrameBroadcaster()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-
-    rclpy.shutdown()

--- a/turtle_tf2_py/turtle_tf2_py/fixed_frame_tf2_broadcaster.py
+++ b/turtle_tf2_py/turtle_tf2_py/fixed_frame_tf2_broadcaster.py
@@ -15,6 +15,7 @@
 from geometry_msgs.msg import TransformStamped
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from tf2_ros import TransformBroadcaster
@@ -45,11 +46,9 @@ class FixedFrameBroadcaster(Node):
 
 
 def main():
-    rclpy.init()
-    node = FixedFrameBroadcaster()
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init():
+            node = FixedFrameBroadcaster()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-
-    rclpy.shutdown()

--- a/turtle_tf2_py/turtle_tf2_py/static_turtle_tf2_broadcaster.py
+++ b/turtle_tf2_py/turtle_tf2_py/static_turtle_tf2_broadcaster.py
@@ -20,6 +20,7 @@ from geometry_msgs.msg import TransformStamped
 import numpy as np
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from tf2_ros.static_transform_broadcaster import StaticTransformBroadcaster
@@ -104,12 +105,10 @@ def main():
         logger.info('Your static turtle name cannot be "world"')
         sys.exit(2)
 
-    # pass parameters and initialize node
-    rclpy.init()
-    node = StaticFramePublisher(sys.argv)
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init():
+            # pass parameters and initialize node
+            node = StaticFramePublisher(sys.argv)
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-
-    rclpy.shutdown()

--- a/turtle_tf2_py/turtle_tf2_py/turtle_tf2_broadcaster.py
+++ b/turtle_tf2_py/turtle_tf2_py/turtle_tf2_broadcaster.py
@@ -19,6 +19,7 @@ from geometry_msgs.msg import TransformStamped
 import numpy as np
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from tf2_ros import TransformBroadcaster
@@ -104,11 +105,9 @@ class FramePublisher(Node):
 
 
 def main():
-    rclpy.init()
-    node = FramePublisher()
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init():
+            node = FramePublisher()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-
-    rclpy.shutdown()

--- a/turtle_tf2_py/turtle_tf2_py/turtle_tf2_listener.py
+++ b/turtle_tf2_py/turtle_tf2_py/turtle_tf2_listener.py
@@ -17,6 +17,7 @@ import math
 from geometry_msgs.msg import Twist
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from tf2_ros import TransformException
@@ -109,11 +110,9 @@ class FrameListener(Node):
 
 
 def main():
-    rclpy.init()
-    node = FrameListener()
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init():
+            node = FrameListener()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-
-    rclpy.shutdown()

--- a/turtle_tf2_py/turtle_tf2_py/turtle_tf2_message_broadcaster.py
+++ b/turtle_tf2_py/turtle_tf2_py/turtle_tf2_message_broadcaster.py
@@ -16,6 +16,7 @@ from geometry_msgs.msg import PointStamped
 from geometry_msgs.msg import Twist
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from turtlesim_msgs.msg import Pose
@@ -87,11 +88,9 @@ class PointPublisher(Node):
 
 
 def main():
-    rclpy.init()
-    node = PointPublisher()
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init():
+            node = PointPublisher()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-
-    rclpy.shutdown()


### PR DESCRIPTION
This ensures that everything will be properly cleaned up when we leave the context manager.

This should be merged simultaneously with https://github.com/ros2/ros2_documentation/pull/4586