### PR TITLE
[ROS-O] do away with boost::bind

### DIFF
--- a/turtle_tf/src/turtle_tf_message_filter.cpp
+++ b/turtle_tf/src/turtle_tf_message_filter.cpp
@@ -10,7 +10,7 @@ public:
   {
     point_sub_.subscribe(n_, "turtle_point_stamped", 10);
     tf_filter_ = new tf::MessageFilter<geometry_msgs::PointStamped>(point_sub_, tf_, target_frame_, 10);
-    tf_filter_->registerCallback( boost::bind(&PoseDrawer::msgCallback, this, _1) );
+    tf_filter_->registerCallback( [this](auto& msg){ msgCallback(msg); } );
   } ;
 
 private:

--- a/turtle_tf2/src/message_filter.cpp
+++ b/turtle_tf2/src/message_filter.cpp
@@ -14,7 +14,7 @@ public:
     tf2_filter_(point_sub_, buffer_, target_frame_, 10, 0)
   {
     point_sub_.subscribe(n_, "turtle_point_stamped", 10);
-    tf2_filter_.registerCallback( boost::bind(&PoseDrawer::msgCallback, this, _1) );
+    tf2_filter_.registerCallback( [this](auto& msg){ msgCallback(msg); } );
   }
 
   //  Callback to register with tf2_ros::MessageFilter to be called when transforms are available


### PR DESCRIPTION
literal boost _1 is deprecated for a long time due to std::bind. lambas are preferred.

This line started failing with [a recently proposed patch in ROS-O](https://github.com/ros-o/ros_comm/pull/3).

Note: Using the lambda requires melodic+, so you should create a new melodic/noetic branch for this.
(I'm also happy to use the alternative `boost::placeholders::` prefix if you prefer that).